### PR TITLE
add panorama server general setting

### DIFF
--- a/docs/resources/general_settings.md
+++ b/docs/resources/general_settings.md
@@ -37,6 +37,8 @@ The following arguments are supported:
 * `proxy_port` - (int, 1.5+) Proxy's port number.
 * `proxy_username` - (1.5+) Proxy's username.
 * `proxy_password` - (1.5+) Proxy's password.
+* `panorama_primary`- Primary Panorama server.
+* `panorama_secondary`- Secondary Panorama server.
 * `dns_primary` - Primary DNS server.
 * `dns_secondary` - Secondary DNS server.
 * `ntp_primary_address` - Primary NTP server.

--- a/panos/resource_general_settings.go
+++ b/panos/resource_general_settings.go
@@ -71,6 +71,18 @@ func resourceGeneralSettings() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"panorama_primary": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "Primary Panorama server address",
+			},
+			"panorama_secondary": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "Secondary Panorama server address",
+			},
 			"dns_primary": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -162,6 +174,8 @@ func parseGeneralSettings(d *schema.ResourceData) general.Config {
 		ProxyPort:             d.Get("proxy_port").(int),
 		ProxyUser:             d.Get("proxy_user").(string),
 		ProxyPassword:         d.Get("proxy_password").(string),
+		PanoramaPrimary:       d.Get("panorama_primary").(string),
+		PanoramaSecondary:     d.Get("panorama_secondary").(string),
 		DnsPrimary:            d.Get("dns_primary").(string),
 		DnsSecondary:          d.Get("dns_secondary").(string),
 		NtpPrimaryAddress:     d.Get("ntp_primary_address").(string),
@@ -221,6 +235,8 @@ func readGeneralSettings(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("proxy_password_enc").(string) != o.ProxyPassword {
 		d.Set("proxy_password", "(incorrect proxy password)")
 	}
+	d.Set("panorama_primary", o.PanoramaPrimary)
+	d.Set("panorama_secondary", o.PanoramaSecondary)
 	d.Set("dns_primary", o.DnsPrimary)
 	d.Set("dns_secondary", o.DnsSecondary)
 	d.Set("ntp_primary_address", o.NtpPrimaryAddress)

--- a/panos/resource_general_settings_test.go
+++ b/panos/resource_general_settings_test.go
@@ -23,17 +23,17 @@ func TestAccPanosGeneralSettings_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGeneralSettingsConfig("acctest", "10.5.5.5", "10.10.10.10", "autokey"),
+				Config: testAccGeneralSettingsConfig("acctest", "10.15.15.15", "10.5.5.5", "10.10.10.10", "autokey"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPanosGeneralSettingsExists("panos_general_settings.test", &o),
-					testAccCheckPanosGeneralSettingsAttributes(&o, "acctest", "10.5.5.5", "10.10.10.10", "autokey"),
+					testAccCheckPanosGeneralSettingsAttributes(&o, "acctest", "10.15.15.15", "10.5.5.5", "10.10.10.10", "autokey"),
 				),
 			},
 			{
-				Config: testAccGeneralSettingsConfig("ngfw", "10.15.15.15", "10.20.20.20", "none"),
+				Config: testAccGeneralSettingsConfig("ngfw", "10.25.25.25", "10.15.15.15", "10.20.20.20", "none"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPanosGeneralSettingsExists("panos_general_settings.test", &o),
-					testAccCheckPanosGeneralSettingsAttributes(&o, "ngfw", "10.15.15.15", "10.20.20.20", "none"),
+					testAccCheckPanosGeneralSettingsAttributes(&o, "ngfw", "10.25.25.25", "10.15.15.15", "10.20.20.20", "none"),
 				),
 			},
 		},
@@ -63,10 +63,14 @@ func testAccCheckPanosGeneralSettingsExists(n string, o *general.Config) resourc
 	}
 }
 
-func testAccCheckPanosGeneralSettingsAttributes(o *general.Config, h, ds, nsa, nsat string) resource.TestCheckFunc {
+func testAccCheckPanosGeneralSettingsAttributes(o *general.Config, h, ps, ds, nsa, nsat string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if o.Hostname != h {
 			return fmt.Errorf("Hostname is %s, expected %s", o.Hostname, h)
+		}
+
+		if o.PanoramaSecondary != ds {
+			return fmt.Errorf("Secondary Panorama is %s, expected %s", o.PanoramaSecondary, ps)
 		}
 
 		if o.DnsSecondary != ds {
@@ -85,13 +89,14 @@ func testAccCheckPanosGeneralSettingsAttributes(o *general.Config, h, ds, nsa, n
 	}
 }
 
-func testAccGeneralSettingsConfig(h, ds, nsa, nsat string) string {
+func testAccGeneralSettingsConfig(h, ps, ds, nsa, nsat string) string {
 	return fmt.Sprintf(`
 resource "panos_general_settings" "test" {
     hostname = "%s"
+    panorama_secondary = "%s"
     dns_secondary = "%s"
     ntp_secondary_address = "%s"
     ntp_secondary_auth_type = "%s"
 }
-`, h, ds, nsa, nsat)
+`, h, ps, ds, nsa, nsat)
 }


### PR DESCRIPTION
✅ ~~Pending https://github.com/PaloAltoNetworks/pango/pull/57~~

## Description

Add support for primary and secondary Panorama server(s) under general settings.

## Motivation and Context

The option to set the Panorama servers were not available

## How Has This Been Tested?

Tested the code on two newly created AWS EC2 Palo Alto instances.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
