### PR TITLE
Adding argument for keepers in the resource vm auth key

### DIFF
--- a/docs/resources/vm_auth_key.md
+++ b/docs/resources/vm_auth_key.md
@@ -25,6 +25,7 @@ resource "panos_vm_auth_key" "example" {
 The following arguments are supported:
 
 * `hours` - (int) The VM auth key lifetime in hours.
+* `keepers` - (map) Arbitrary map of values that, when changed, will trigger a new key to be generated.
 
 
 ## Attribute Reference

--- a/panos/vm_auth_key.go
+++ b/panos/vm_auth_key.go
@@ -104,6 +104,12 @@ func resourceVmAuthKey() *schema.Resource {
 				Default:     8,
 				Description: "The VM auth key lifetime",
 			},
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
 			"auth_key": {
 				Type:        schema.TypeString,
 				Computed:    true,


### PR DESCRIPTION
## Description

Add support to recreate vm auth token with an argument named keepers. Adding this functionality to recreate token if resources change/update or to be used with the terraform resource time_rotating. 

## Motivation and Context

This allows the token to be recreated when the token expires using the terraform resource `time_rotating`.

Example:
```
resource "time_rotating" "example" {
  rotation_hours = 24
}

resource "panos_vm_auth_key" "example" {
    hours = 24
    keepers = {
        rotate = time_rotating.example.rotation_rfc3339
    }
}
```

## How Has This Been Tested?

Have tested it on a new Palo instance in Azure

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/36347519/120697098-4d30d700-c47b-11eb-8779-10fa34bfe918.png)


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist

- [ x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (Would someone point me in the right direction for this document)
- [x] I have added tests to cover my changes if appropriate.(Please let me know if i need to add test for this change)
- [x] All new and existing tests passed.
