### PR TITLE
template/template_stack: can't both be enforced yet conflicting

### DIFF
--- a/panos/schemas.go
+++ b/panos/schemas.go
@@ -16,7 +16,6 @@ func templateSchema(ts bool) *schema.Schema {
 
 	if ts {
 		ans.Optional = true
-		ans.ConflictsWith = []string{"template_stack"}
 	} else {
 		ans.Required = true
 	}
@@ -29,7 +28,6 @@ func templateStackSchema() *schema.Schema {
 		Type:          schema.TypeString,
 		Optional:      true,
 		ForceNew:      true,
-		ConflictsWith: []string{"template"},
 	}
 }
 


### PR DESCRIPTION
Likely closes #294

The template and template_stack objects are enforced when running
plan/apply against imported objects; otherwise the engine would
want to completely replace the objects, which would likely cause
consistency issues with the rest of the configuration.

Since they are both enforced; they can't also be conflicting; that
leads to an impossible scenario where you must but can't define
both a template and template_stack.

Signed-off-by: Mathieu Trudel-Lapierre <mtrudel@stack8.com>

## Description

Make these schema fields not conflicting

## Motivation and Context

See above

## How Has This Been Tested?

Not tested yet; saving for an initial discussion on the idea.


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
