### PR TITLE
bugfix: make nat_rule_group work with panorama and ngfw

### DIFF
--- a/panos/resource_nat_rule_group_test.go
+++ b/panos/resource_nat_rule_group_test.go
@@ -53,7 +53,7 @@ func testAccCheckPanosNatRuleGroupExists(top, bot string, o1, o2, o3 *nat.Entry)
 		if rTop.Primary.ID == "" {
 			return fmt.Errorf("Object label ID is not set")
 		}
-		vsys, _, _, topList := parseNatRuleGroupId(rTop.Primary.ID)
+		_, _, vsys, _, _, topList := parseNatRuleGroupId(rTop.Primary.ID)
 		if len(topList) != 1 {
 			return fmt.Errorf("top is not len 1")
 		}
@@ -71,7 +71,7 @@ func testAccCheckPanosNatRuleGroupExists(top, bot string, o1, o2, o3 *nat.Entry)
 		if rBot.Primary.ID == "" {
 			return fmt.Errorf("Object label ID is not set")
 		}
-		vsys, _, _, botList := parseNatRuleGroupId(rBot.Primary.ID)
+		_, _, vsys, _, _, botList := parseNatRuleGroupId(rBot.Primary.ID)
 		if len(botList) != 2 {
 			return fmt.Errorf("bot is not len 2")
 		}
@@ -212,7 +212,7 @@ func testAccPanosNatRuleGroupDestroy(s *terraform.State) error {
 		}
 
 		if rs.Primary.ID != "" {
-			vsys, _, _, list := parseNatRuleGroupId(rs.Primary.ID)
+			_, _, vsys, _, _, list := parseNatRuleGroupId(rs.Primary.ID)
 			for _, rule := range list {
 				_, err := fw.Policies.Nat.Get(vsys, rule)
 				if err == nil {

--- a/panos/resource_panorama_ike_crypto_profile_test.go
+++ b/panos/resource_panorama_ike_crypto_profile_test.go
@@ -63,7 +63,7 @@ func testAccCheckPanosPanoramaIkeCryptoProfileExists(n string, o *ike.Entry) res
 		}
 
 		pano := testAccProvider.Meta().(*pango.Panorama)
-		tmpl, ts, name := parsePanoramaIkeCryptoProfileId(rs.Primary.ID)
+		tmpl, ts, name := parseIkeCryptoProfileId(rs.Primary.ID)
 		v, err := pano.Network.IkeCryptoProfile.Get(tmpl, ts, name)
 		if err != nil {
 			return fmt.Errorf("Error in get: %s", err)
@@ -114,7 +114,7 @@ func testAccPanosPanoramaIkeCryptoProfileDestroy(s *terraform.State) error {
 		}
 
 		if rs.Primary.ID != "" {
-			tmpl, ts, name := parsePanoramaIkeCryptoProfileId(rs.Primary.ID)
+			tmpl, ts, name := parseIkeCryptoProfileId(rs.Primary.ID)
 			_, err := pano.Network.IkeCryptoProfile.Get(tmpl, ts, name)
 			if err == nil {
 				return fmt.Errorf("Object %q still exists", name)

--- a/panos/resource_panorama_nat_rule_group_test.go
+++ b/panos/resource_panorama_nat_rule_group_test.go
@@ -55,7 +55,7 @@ func testAccCheckPanosPanoramaNatRuleGroupExists(top, bot string, o1, o2, o3 *na
 		if rTop.Primary.ID == "" {
 			return fmt.Errorf("Object label ID is not set")
 		}
-		dg, rb, _, _, topList := parsePanoramaNatRuleGroupId(rTop.Primary.ID)
+		dg, rb, _, _, _, topList := parseNatRuleGroupId(rTop.Primary.ID)
 		if len(topList) != 1 {
 			return fmt.Errorf("top is not len 1")
 		}
@@ -73,7 +73,7 @@ func testAccCheckPanosPanoramaNatRuleGroupExists(top, bot string, o1, o2, o3 *na
 		if rBot.Primary.ID == "" {
 			return fmt.Errorf("Object label ID is not set")
 		}
-		dg, rb, _, _, botList := parsePanoramaNatRuleGroupId(rBot.Primary.ID)
+		dg, rb, _, _, _, botList := parseNatRuleGroupId(rBot.Primary.ID)
 		if len(botList) != 2 {
 			return fmt.Errorf("bot is not len 2")
 		}
@@ -214,7 +214,7 @@ func testAccPanosPanoramaNatRuleGroupDestroy(s *terraform.State) error {
 		}
 
 		if rs.Primary.ID != "" {
-			dg, rb, _, _, list := parsePanoramaNatRuleGroupId(rs.Primary.ID)
+			dg, rb, _, _, _, list := parseNatRuleGroupId(rs.Primary.ID)
 			for _, rule := range list {
 				_, err := pano.Policies.Nat.Get(dg, rb, rule)
 				if err == nil {


### PR DESCRIPTION
## Description

Based on [documentation](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/nat_rule_group) nat_rule_group should work either with Panorama and NGFW, right now it not work as intended. 
+ quick fix for ike_crypto_profile_tests.

## Motivation and Context

It fix nat_rule_group resource to behave what was said in documentation.

## How Has This Been Tested?

I build provider, test it with Terraform code and do go tests.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
