### PR TITLE
adding lifecycle attribute to examples of resources

### DIFF
--- a/docs/data-sources/address_object.md
+++ b/docs/data-sources/address_object.md
@@ -28,6 +28,10 @@ resource "panos_address_object" "x" {
         "internal",
         "dmz",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/anti_spyware_security_profile.md
+++ b/docs/data-sources/anti_spyware_security_profile.md
@@ -42,6 +42,10 @@ resource "panos_anti_spyware_security_profile" "x" {
         name = data.panos_predefined_threat.dot_net.threats.0.name
         action = "allow"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_predefined_threat" "dot_net" {

--- a/docs/data-sources/antivirus_security_profile.md
+++ b/docs/data-sources/antivirus_security_profile.md
@@ -32,6 +32,10 @@ resource "panos_antivirus_security_profile" "x" {
         application = "hotmail"
         action = "alert"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/arp.md
+++ b/docs/data-sources/arp.md
@@ -25,10 +25,18 @@ resource "panos_arp" "x" {
     interface_name = panos_panorama_ethernet_interface.x.name
     ip = "10.5.6.7"
     mac_address = "00:30:48:52:11:22"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "x" {
     name = "template one"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "x" {
@@ -36,6 +44,10 @@ resource "panos_panorama_ethernet_interface" "x" {
     name = "ethernet1/1"
     vsys = "vsys1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 
@@ -53,10 +65,18 @@ resource "panos_arp" "y" {
     interface_name = panos_panorama_aggregate_interface.y.name
     ip = "10.5.6.7"
     mac_address = "00:30:48:52:22:33"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "y" {
     name = "template two"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_aggregate_interface" "y" {
@@ -64,6 +84,10 @@ resource "panos_panorama_aggregate_interface" "y" {
     name = "ae1"
     vsys = "vsys1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 
@@ -83,16 +107,28 @@ resource "panos_arp" "z" {
     subinterface_name = panos_panorama_vlan_interface.z.name
     ip = "10.5.6.7"
     mac_address = "00:30:48:52:33:44"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resourcee "panos_panorama_template" "z" {
     name = "template three"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_vlan_interface" "z" {
     template = panos_panorama_template.z.name
     name = "vlan.42"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/audit_comment_history.md
+++ b/docs/data-sources/audit_comment_history.md
@@ -29,6 +29,10 @@ resource "panos_security_rule_group" "x" {
         description = "Made by Terraform"
         ...
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -44,6 +48,10 @@ data "panos_audit_comment_history" "example" {
 
 resource "panos_panorama_device_group" "x" {
     name = "my device group"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_security_rule_group" "x" {
@@ -53,6 +61,10 @@ resource "panos_security_rule_group" "x" {
         name = "Allow eng to DMZ"
         description = "Made by Terraform"
         ...
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/data-sources/custom_data_pattern_object.md
+++ b/docs/data-sources/custom_data_pattern_object.md
@@ -24,6 +24,10 @@ resource "panos_custom_data_pattern_object" "predef" {
         name = "social-security-numbers"
         file_types = ["docx", "xlsx"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 
@@ -40,6 +44,10 @@ resource "panos_custom_data_pattern_object" "regex" {
         name = "blah"
         file_types = ["docx", "doc", "text/html"]
         regex = "shin megami tensei"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 
@@ -58,6 +66,10 @@ resource "panos_custom_data_pattern_object" "file_prop" {
         file_type = data.panos_predefined_dlp_file_type.pdf_keywords.name
         file_property = data.panos_predefined_dlp_file_type.pdf_keywords.file_types.0.properties.0.name
         property_value = "foo"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 

--- a/docs/data-sources/data_filtering_security_profile.md
+++ b/docs/data-sources/data_filtering_security_profile.md
@@ -23,6 +23,10 @@ resource "panos_data_filtering_security_profile" "x" {
         applications = ["any"]
         file_types = ["any"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_custom_data_pattern_object" "my_custom_obj" {
@@ -33,6 +37,10 @@ resource "panos_custom_data_pattern_object" "my_custom_obj" {
         name = "my regex"
         file_types = ["any"]
         regex = "this is my regex"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/data-sources/decryption_rule.md
+++ b/docs/data-sources/decryption_rule.md
@@ -24,6 +24,10 @@ data "panos_decryption_rule_group" "example" {
 
 resource "panos_panorama_device_group" "x" {
     name = "my device group"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/dos_protection_profile.md
+++ b/docs/data-sources/dos_protection_profile.md
@@ -26,6 +26,10 @@ resource "panos_dos_protection_profile" "x"
         max_rate = 999
         block_duration = 42
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/dynamic_user_group.md
+++ b/docs/data-sources/dynamic_user_group.md
@@ -22,6 +22,10 @@ resource "panos_dynamic_user_group" "x" {
     name = "example"
     description = "made by Terraform"
     filter = "'tomato'"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/file_blocking_security_profile.md
+++ b/docs/data-sources/file_blocking_security_profile.md
@@ -23,6 +23,10 @@ resource "panos_file_blocking_security_profile" "x"
         applications = ["bbc-streaming"]
         file_types = ["ogg"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/ospf.md
+++ b/docs/data-sources/ospf.md
@@ -27,15 +27,27 @@ resource "panos_ospf" "x" {
     lsa_interval = 3
     max_neighbor_restart_time = 141
     spf_calculation_delay = 4
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }       
 ```
 

--- a/docs/data-sources/ospf_area.md
+++ b/docs/data-sources/ospf_area.md
@@ -26,21 +26,37 @@ resource "panos_ospf_area" "x" {
     default_route_advertise = true
     advertise_metric = 50
     advertise_type = "ext-2"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf" "x" {
     template = panos_panorama_template.x.name
     virtual_router = panos_panorama_virtual_router.x.name
     enable = true
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }       
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/ospf_export.md
+++ b/docs/data-sources/ospf_export.md
@@ -39,20 +39,36 @@ resource "panos_ospf_export" "x" {
     name = "10.2.3.0/24"
     tag = "10.5.15.151"
     metric = 42
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf" "x" {
     template = panos_panorama_template.x.name
     virtual_router = panos_panorama_virtual_router.x.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }       
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/data-sources/url_filtering_security_profile.md
+++ b/docs/data-sources/url_filtering_security_profile.md
@@ -43,6 +43,10 @@ resource "panos_url_filtering_security_profile" "x" {
             value = "beta"
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}

--- a/docs/data-sources/vulnerability_security_profile.md
+++ b/docs/data-sources/vulnerability_security_profile.md
@@ -32,6 +32,10 @@ resource "panos_vulnerability_security_profile" "x" {
         name = data.panos_predefined_threat.siemens_overflow.threats.0.name
         action = "drop"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_predefined_threat" "siemens_overflow" {

--- a/docs/data-sources/wildfire_analysis_security_profile.md
+++ b/docs/data-sources/wildfire_analysis_security_profile.md
@@ -41,6 +41,10 @@ resource "panos_wildfire_analysis_security_profile" "x" {
         applications = ["pop3"]
         file_types = ["pdf"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/address_group.md
+++ b/docs/resources/address_group.md
@@ -35,16 +35,28 @@ resource "panos_address_group" "example1" {
         panos_address_object.ao1.name,
         panos_address_object.ao2.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_address_object" "ao1" {
     name = "ntp1"
     value = "10.0.0.1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_address_object" "ao2" {
     name = "ntp2"
     value = "10.0.0.2"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -54,6 +66,10 @@ resource "panos_address_group" "example2" {
     name = "dynamic grp"
     description = "My internal NTP servers"
     dynamic_match = "'internal' and 'ntp'"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/address_object.md
+++ b/docs/resources/address_object.md
@@ -47,6 +47,10 @@ resource "panos_address_object" "example" {
         "internal",
         "dmz",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/address_objects.md
+++ b/docs/resources/address_objects.md
@@ -94,6 +94,10 @@ resource "panos_address_objects" "ao1" {
         type = "ip-netmask"
         value = "10.1.1.1"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
     ...
 }
 
@@ -102,6 +106,10 @@ resource "panos_address_objects" "ao2" {
         name = "bar"
         type = "ip-netmask"
         value = "10.1.1.2"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
     ...
 }

--- a/docs/resources/administrative_tag.md
+++ b/docs/resources/administrative_tag.md
@@ -73,6 +73,10 @@ resource "panos_administrative_tag" "example" {
     vsys = "vsys2"
     color = "color5"
     comment = "Internal resources"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/aggregate_interface.md
+++ b/docs/resources/aggregate_interface.md
@@ -29,6 +29,10 @@ resource "panos_aggregate_interface" "example" {
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/anti_spyware_security_profile.md
+++ b/docs/resources/anti_spyware_security_profile.md
@@ -52,6 +52,10 @@ resource "panos_anti_spyware_security_profile" "example" {
         name = data.panos_predefined_threat.dot_net.threats.0.name
         action = "allow"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_predefined_threat" "dot_net" {

--- a/docs/resources/antivirus_security_profile.md
+++ b/docs/resources/antivirus_security_profile.md
@@ -43,6 +43,10 @@ resource "panos_antivirus_security_profile" "example" {
         application = "hotmail"
         action = "alert"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/application_group.md
+++ b/docs/resources/application_group.md
@@ -29,16 +29,28 @@ resource "panos_application_group" "example" {
         panos_application_object.a1.name,
         panos_application_object.a2.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_application_object" "a1" {
     name = "app1"
     ...
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_application_object" "a2" {
     name = "app2"
     ...
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/application_object.md
+++ b/docs/resources/application_object.md
@@ -40,6 +40,10 @@ resource "panos_application_object" "example" {
     scanning {
         viruses = true
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/application_signature.md
+++ b/docs/resources/application_signature.md
@@ -63,6 +63,10 @@ resource "panos_application_signature" "example" {
             }
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_application_object" "myapp" {
@@ -81,6 +85,10 @@ resource "panos_application_object" "myapp" {
     risk = 4
     scanning {
         viruses = true
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/arp.md
+++ b/docs/resources/arp.md
@@ -33,10 +33,18 @@ resource "panos_arp" "example1" {
     interface_name = panos_panorama_ethernet_interface.x.name
     ip = "10.5.6.7"
     mac_address = "00:30:48:52:11:22"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "x" {
     name = "template one"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "x" {
@@ -44,6 +52,10 @@ resource "panos_panorama_ethernet_interface" "x" {
     name = "ethernet1/1"
     vsys = "vsys1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 
@@ -54,10 +66,18 @@ resource "panos_arp" "example2" {
     interface_name = panos_panorama_aggregate_interface.y.name
     ip = "10.5.6.7"
     mac_address = "00:30:48:52:22:33"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "y" {
     name = "template two"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_aggregate_interface" "y" {
@@ -65,6 +85,10 @@ resource "panos_panorama_aggregate_interface" "y" {
     name = "ae1"
     vsys = "vsys1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 
@@ -77,16 +101,28 @@ resource "panos_arp" "example3" {
     subinterface_name = panos_panorama_vlan_interface.z.name
     ip = "10.5.6.7"
     mac_address = "00:30:48:52:33:44"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
-resourcee "panos_panorama_template" "z" {
+resource "panos_panorama_template" "z" {
     name = "template three"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_vlan_interface" "z" {
     template = panos_panorama_template.z.name
     name = "vlan.42"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bfd_profile.md
+++ b/docs/resources/bfd_profile.md
@@ -30,6 +30,10 @@ NGFW
 ```hcl
 resource "panos_bfd_profile" "example" {
     name = "myBfdProfile"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -35,10 +35,18 @@ resource "panos_bgp" "example" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_aggregate.md
+++ b/docs/resources/bgp_aggregate.md
@@ -29,16 +29,28 @@ resource "panos_bgp_aggregate" "example" {
     name = "myAggRule"
     prefix = "192.168.1.0/24"
     weight = 17
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.vr.name
     router_id = "1.2.3.4"
     as_number = 443
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "vr" {
     name = "my vr"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_aggregate_advertise_filter.md
+++ b/docs/resources/bgp_aggregate_advertise_filter.md
@@ -37,22 +37,38 @@ resource "panos_bgp_aggregate_advertise_filter" "example" {
     address_prefix {
         prefix = "10.1.2.0/24"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_aggregate" "ag" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "addyAgg1"
     prefix = "192.168.1.0/24"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_aggregate_suppress_filter.md
+++ b/docs/resources/bgp_aggregate_suppress_filter.md
@@ -37,22 +37,38 @@ resource "panos_bgp_aggregate_suppress_filter" "example" {
     address_prefix {
         prefix = "10.1.2.0/24"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_aggregate" "ag" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "addyAgg1"
     prefix = "192.168.1.0/24"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_auth_profile.md
+++ b/docs/resources/bgp_auth_profile.md
@@ -20,16 +20,28 @@ resource "panos_bgp_auth_profile" "example" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "prof1"
     secret = "secret"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_conditional_adv.md
+++ b/docs/resources/bgp_conditional_adv.md
@@ -37,6 +37,10 @@ resource "panos_bgp_conditional_adv" "example" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "example"
     enable = false
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_conditional_adv_non_exist_filter" "nef" {
@@ -45,6 +49,10 @@ resource "panos_bgp_conditional_adv_non_exist_filter" "nef" {
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     name = "nef"
     address_prefixes = ["192.168.1.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_conditional_adv_advertise_filter" "af" {
@@ -53,16 +61,28 @@ resource "panos_bgp_conditional_adv_advertise_filter" "af" {
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     name = "af"
     address_prefixes = ["192.168.2.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_conditional_adv_advertise_filter.md
+++ b/docs/resources/bgp_conditional_adv_advertise_filter.md
@@ -36,11 +36,19 @@ resource "panos_bgp_conditional_adv_advertise_filter" "example" {
     name = "af"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.1.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_conditional_adv" "ca" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "example"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_conditional_adv_non_exist_filter" "af" {
@@ -49,16 +57,28 @@ resource "panos_bgp_conditional_adv_non_exist_filter" "af" {
     name = "nef"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.2.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_conditional_adv_non_exist_filter.md
+++ b/docs/resources/bgp_conditional_adv_non_exist_filter.md
@@ -36,11 +36,19 @@ resource "panos_bgp_conditional_adv_non_exist_filter" "example" {
     name = "nef"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.1.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_conditional_adv" "ca" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "example"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_conditional_adv_advertise_filter" "af" {
@@ -49,16 +57,28 @@ resource "panos_bgp_conditional_adv_advertise_filter" "af" {
     name = "af"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.2.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_dampening_profile.md
+++ b/docs/resources/bgp_dampening_profile.md
@@ -26,16 +26,28 @@ NGFW
 resource "panos_bgp_dampening_profile" "example" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "myDampeningProfile"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_export_rule_group.md
+++ b/docs/resources/bgp_export_rule_group.md
@@ -64,6 +64,10 @@ resource "panos_bgp_export_rule_group" "example" {
         action = "deny"
         match_route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}
@@ -72,10 +76,18 @@ resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.vr.name
     router_id = "1.2.3.4"
     as_number = 443
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "vr" {
     name = "my vr"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_import_rule_group.md
+++ b/docs/resources/bgp_import_rule_group.md
@@ -64,6 +64,10 @@ resource "panos_bgp_import_rule_group" "example" {
         action = "deny"
         match_route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}
@@ -72,10 +76,18 @@ resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.vr.name
     router_id = "1.2.3.4"
     as_number = 443
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "vr" {
     name = "my vr"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_peer.md
+++ b/docs/resources/bgp_peer.md
@@ -47,23 +47,39 @@ resource "panos_bgp_peer" "example" {
             data.panos_system_info.x.version_minor >= 1 ? 30 : 0
         : 0
     }"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp_peer_group" "pg" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "myName"
     type = "ibgp"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
     interfaces = [panos_ethernet_interface.e.name]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e" {
@@ -71,6 +87,10 @@ resource "panos_ethernet_interface" "e" {
     mode = "layer3"
     vsys = "vsys1"
     static_ips = ["192.168.1.1/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_peer_group.md
+++ b/docs/resources/bgp_peer_group.md
@@ -26,16 +26,28 @@ NGFW
 resource "panos_bgp_peer_group" "example" {
     virtual_router = panos_bgp.conf.virtual_router
     name = "myName"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/bgp_redist_rule.md
+++ b/docs/resources/bgp_redist_rule.md
@@ -28,6 +28,10 @@ resource "panos_bgp_redist_rule" "example" {
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     name = "192.168.1.0/24"
     set_med = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}
@@ -36,10 +40,18 @@ resource "panos_bgp" "conf" {
     virtual_router = panos_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "rtr" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/certificate_import.md
+++ b/docs/resources/certificate_import.md
@@ -31,6 +31,10 @@ resource "panos_certificate_import" "example" {
         private_key = file("key.pem")
         passphrase = "secret"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -41,6 +45,10 @@ resource "panos_certificate_import" "example2" {
     pkcs12 {
         certificate = file("cert.pfx")
         passphrase = "foobar"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/certificate_profile.md
+++ b/docs/resources/certificate_profile.md
@@ -34,6 +34,10 @@ resource "panos_certificate_profile" "x" {
         ocsp_verify_certificate = ""
         template_name = ""
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/custom_data_pattern_object.md
+++ b/docs/resources/custom_data_pattern_object.md
@@ -39,6 +39,10 @@ resource "panos_custom_data_pattern_object" "predef" {
         name = "social-security-numbers"
         file_types = ["docx", "xlsx"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 
@@ -51,6 +55,10 @@ resource "panos_custom_data_pattern_object" "regex" {
         name = "blah"
         file_types = ["docx", "doc", "text/html"]
         regex = "shin megami tensei"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 
@@ -69,6 +77,10 @@ resource "panos_custom_data_pattern_object" "file_prop" {
         file_type = data.panos_predefined_dlp_file_type.pdf_keywords.name
         file_property = data.panos_predefined_dlp_file_type.pdf_keywords.file_types.0.properties.0.name
         property_value = "foo"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 

--- a/docs/resources/custom_url_category.md
+++ b/docs/resources/custom_url_category.md
@@ -37,6 +37,10 @@ resource "panos_custom_url_category" "example" {
         "example.com",
     ]
     type = data.panos_system_info.x.version_major >= 9 ? "URL List" : ""
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}

--- a/docs/resources/custom_url_category_entry.md
+++ b/docs/resources/custom_url_category_entry.md
@@ -27,12 +27,20 @@ resource "panos_custom_url_category_entry" "example" {
     vsys = panos_custom_url_category.x.vsys
     custom_url_category = panos_custom_url_category.x.name
     site = "example.com"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_custom_url_category" "x" {
     name = "myCustomCategory"
     description = "Made by Terraform"
     type = data.panos_system_info.x.version_major >= 9 ? "URL List" : ""
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}

--- a/docs/resources/dag_tags.md
+++ b/docs/resources/dag_tags.md
@@ -33,6 +33,10 @@ resource "panos_dag_tags" "example" {
         ip = "10.1.1.2"
         tags = ["tag3"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/data_filtering_security_profile.md
+++ b/docs/resources/data_filtering_security_profile.md
@@ -34,6 +34,10 @@ resource "panos_data_filtering_security_profile" "example" {
         applications = ["any"]
         file_types = ["any"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_custom_data_pattern_object" "my_custom_obj" {
@@ -44,6 +48,10 @@ resource "panos_custom_data_pattern_object" "my_custom_obj" {
         name = "my regex"
         file_types = ["any"]
         regex = "this is my regex"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/decryption_rule_group.md
+++ b/docs/resources/decryption_rule_group.md
@@ -83,10 +83,18 @@ resource "panos_decryption_rule_group" "example1" {
             ]
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_device_group" "x" {
     name = "my device group"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/device_group.md
+++ b/docs/resources/device_group.md
@@ -49,6 +49,10 @@ resource "panos_device_group" "example" {
             "vsys2",
         ]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/device_group_entry.md
+++ b/docs/resources/device_group_entry.md
@@ -47,10 +47,18 @@ Panorama.
 resource "panos_device_group_entry" "example1" {
     device_group = panos_device_group.x.name
     serial = "00112233"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_device_group" "x" {
     name = "my device group"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -60,10 +68,18 @@ resource "panos_device_group_entry" "example2" {
     device_group = panos_device_group.y.name
     serial = "44556677"
     vsys_list = ["vsys1", "vsys2"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_device_group" "y" {
     name = "my other dg"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/device_group_parent.md
+++ b/docs/resources/device_group_parent.md
@@ -28,14 +28,26 @@ Panorama.
 resource "panos_device_group_parent" "example1" {
     device_group = panos_device_group.b.name
     parent = panos_device_group.a.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_device_group" "a" {
     name = "Group A"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_device_group" "b" {
     name = "Group B"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -43,10 +55,18 @@ resource "panos_device_group" "b" {
 # Example 2:  Ensure that "Group C" is under "shared" and has no parent.
 resource "panos_device_group_parent" "example2" {
     device_group = panos_device_group.c.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_device_group" "c" {
     name = "Group C"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/dos_protection_profile.md
+++ b/docs/resources/dos_protection_profile.md
@@ -37,6 +37,10 @@ resource "panos_dos_protection_profile" "example"
         max_rate = 999
         block_duration = 42
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/dynamic_user_group.md
+++ b/docs/resources/dynamic_user_group.md
@@ -33,6 +33,10 @@ resource "panos_dynamic_user_group" "example" {
     name = "example"
     description = "made by Terraform"
     filter = "'tomato'"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/edl.md
+++ b/docs/resources/edl.md
@@ -59,6 +59,10 @@ resource "panos_edl" "example" {
     source = "https://example.com"
     repeat = "every five minutes"
     exceptions = ["10.1.1.1", "10.1.1.2"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/email_server_profile.md
+++ b/docs/resources/email_server_profile.md
@@ -33,6 +33,10 @@ resource "panos_email_server_profile" "example" {
         to_email = "alerts@example.com"
         email_gateway = "mail.example.com"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ethernet_interface.md
+++ b/docs/resources/ethernet_interface.md
@@ -30,6 +30,10 @@ resource "panos_ethernet_interface" "example" {
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -42,6 +46,10 @@ resource "panos_ethernet_interface" "example" {
     enable_dhcp = true
     create_dhcp_default_route = true
     dhcp_default_route_metric = 10
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/file_blocking_security_profile.md
+++ b/docs/resources/file_blocking_security_profile.md
@@ -37,6 +37,10 @@ resource "panos_file_blocking_security_profile" "example"
         applications = ["bbc-streaming"]
         file_types = ["ogg"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/general_settings.md
+++ b/docs/resources/general_settings.md
@@ -27,6 +27,10 @@ resource "panos_general_settings" "example" {
     dns_primary = "10.5.1.10"
     ntp_primary = "10.5.1.10"
     ntp_primary_auth_type = "none"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/gre_tunnel.md
+++ b/docs/resources/gre_tunnel.md
@@ -34,6 +34,10 @@ resource "panos_gre_tunnel" "example" {
     peer_address = "192.168.1.1"
     tunnel_interface = panos_tunnel_interface.ti.name
     ttl = 42
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "ei" {
@@ -41,11 +45,19 @@ resource "panos_ethernet_interface" "ei" {
     vsys = "vsys1"
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_tunnel_interface" "ti" {
     name = "tunnel.7"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/http_server_profile.md
+++ b/docs/resources/http_server_profile.md
@@ -36,6 +36,10 @@ resource "panos_http_server_profile" "example" {
         certificate_profile = data.panos_system_info.x.version_major >= 9 ? "None" : ""
         tls_version = data.panos_system_info.x.version_major >= 9 ? "1.2" : ""
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}

--- a/docs/resources/ike_crypto_profile.md
+++ b/docs/resources/ike_crypto_profile.md
@@ -41,6 +41,10 @@ resource "panos_ike_crypto_profile" "example" {
     encryptions = ["des"]
     lifetime_value = 8
     authentication_multiple = 3
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ike_gateway.md
+++ b/docs/resources/ike_gateway.md
@@ -26,6 +26,10 @@ resource "panos_ike_gateway" "example" {
     peer_id_type = "ipaddr"
     peer_id_value = "10.5.1.1"
     ikev1_crypto_profile = "myIkeProfile"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ip_tag.md
+++ b/docs/resources/ip_tag.md
@@ -25,6 +25,10 @@ resource "panos_ip_tag" "example1" {
         "tag1",
         "tag2",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 # It is safe to have multiple resources target the same IP.
@@ -33,6 +37,10 @@ resource "panos_ip_tag" "example2" {
     tags = [
         "tag3",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ipsec_crypto_profile.md
+++ b/docs/resources/ipsec_crypto_profile.md
@@ -32,6 +32,10 @@ resource "panos_ipsec_crypto_profile" "example" {
     lifetime_value = 4
     lifesize_type = "mb"
     lifesize_value = 1
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ipsec_tunnel.md
+++ b/docs/resources/ipsec_tunnel.md
@@ -28,6 +28,10 @@ resource "panos_ipsec_tunnel" "example" {
     anti_replay = true
     ak_ike_gateway = "myIkeGateway"
     ak_ipsec_crypto_profile = "myIkeProfile"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ipsec_tunnel_proxy_id_ipv4.md
+++ b/docs/resources/ipsec_tunnel_proxy_id_ipv4.md
@@ -30,6 +30,10 @@ resource "panos_ipsec_tunnel_proxy_id_ipv4" "example" {
     local = "10.1.1.1"
     remote = "10.2.1.1"
     protocol_any = true
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/layer2_subinterface.md
+++ b/docs/resources/layer2_subinterface.md
@@ -29,12 +29,20 @@ resource "panos_layer2_subinterface" "example" {
     vsys = "vsys1"
     name = "${panos_ethernet_interface.e.name}.5"
     tag = 5
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e" {
     name = "ethernet1/5"
     vsys = "vsys1"
     mode = "layer2"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/layer3_subinterface.md
+++ b/docs/resources/layer3_subinterface.md
@@ -30,12 +30,20 @@ resource "panos_layer3_subinterface" "example" {
     tag = 5
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e" {
     name = "ethernet1/5"
     vsys = "vsys1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/license_api_key.md
+++ b/docs/resources/license_api_key.md
@@ -27,6 +27,10 @@ NGFW
 resource "panos_license_api_key" "example" {
     key = "secret"
     retain_key = true
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/licensing.md
+++ b/docs/resources/licensing.md
@@ -26,6 +26,10 @@ resource "panos_licensing" "example" {
         "code1",
         "code2",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/local_user_db_group.md
+++ b/docs/resources/local_user_db_group.md
@@ -29,16 +29,28 @@ resource "panos_local_user_db_group" "example" {
         panos_local_user_db_user.one.name,
         panos_local_user_db_user.two.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_local_user_db_user" "one" {
     name = "wu"
     password = "password"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_local_user_db_user" "two" {
     name = "tang"
     password = "drowssap"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/local_user_db_user.md
+++ b/docs/resources/local_user_db_user.md
@@ -20,6 +20,10 @@ resource "panos_local_user_db_user" "one" {
     name = "wu"
     password = "password"
     disabled = false
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/log_forwarding_profile.md
+++ b/docs/resources/log_forwarding_profile.md
@@ -54,6 +54,10 @@ resource "panos_log_forwarding_profile" "example" {
             azure_integration { }
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_http_server_profile" "h1" {
@@ -61,6 +65,10 @@ resource "panos_http_server_profile" "h1" {
     http_server {
         name = "h1"
         address = "h1.example.com"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 
@@ -70,11 +78,19 @@ resource "panos_http_server_profile" "h2" {
         name = "h2"
         address = "h2.example.com"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_administrative_tag" "t" {
     name = "myTag"
     color = "color12"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/loopback_interface.md
+++ b/docs/resources/loopback_interface.md
@@ -27,6 +27,10 @@ resource "panos_loopback_interface" "example1" {
     name = "loopback.2"
     comment = "my loopback interface"
     static_ips = ["10.1.1.1"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/management_profile.md
+++ b/docs/resources/management_profile.md
@@ -27,6 +27,10 @@ resource "panos_management_profile" "example" {
     name = "allow ping"
     ping = true
     permitted_ips = ["10.1.1.0/24", "192.168.80.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/monitor_profile.md
+++ b/docs/resources/monitor_profile.md
@@ -31,6 +31,10 @@ resource "panos_monitor_profile" "example" {
     name = "myProfile"
     interval = 5
     threshold = 3
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/nat_rule.md
+++ b/docs/resources/nat_rule.md
@@ -43,22 +43,38 @@ resource "panos_nat_rule" "example" {
     sat_type = "none"
     dat_type = "static"
     dat_address = "my dat address object"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "z1" {
     name = "zone1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "z2" {
     name = "zone2"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e1" {
     name = "ethernet1/3"
     vsys = "vsys1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/nat_rule_group.md
+++ b/docs/resources/nat_rule_group.md
@@ -86,6 +86,10 @@ resource "panos_nat_rule_group" "bot" {
             destination {}
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_nat_rule_group" "top" {
@@ -118,6 +122,10 @@ resource "panos_nat_rule_group" "top" {
             }
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "x" {
@@ -125,21 +133,37 @@ resource "panos_ethernet_interface" "x" {
     mode = "layer3"
     vsys = "vsys1"
     static_ips = ["10.5.5.1/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "z1" {
     name = "z1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "z2" {
     name = "z2"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "z3" {
     name = "z3"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ospf.md
+++ b/docs/resources/ospf.md
@@ -37,15 +37,27 @@ resource "panos_ospf" "example" {
     lsa_interval = 3
     max_neighbor_restart_time = 141
     spf_calculation_delay = 4
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }       
 ```
 

--- a/docs/resources/ospf_area.md
+++ b/docs/resources/ospf_area.md
@@ -35,21 +35,37 @@ resource "panos_ospf_area" "example" {
     default_route_advertise = true
     advertise_metric = 50
     advertise_type = "ext-2"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf" "x" {
     template = panos_panorama_template.x.name
     virtual_router = panos_panorama_virtual_router.x.name
     enable = true
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }       
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ospf_area_interface.md
+++ b/docs/resources/ospf_area_interface.md
@@ -34,10 +34,18 @@ resource "panos_ospf_area_interface" "example" {
     name = panos_panorama_ethernet_interface.x.name
     enable = true
     passive = true
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "x" {
@@ -45,23 +53,39 @@ resource "panos_panorama_ethernet_interface" "x" {
     name = "ethernet1/3"
     mode = "layer3"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     interfaces = [panos_panorama_ethernet_interface.x.name]
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf" "x" {
     template = panos_panorama_virtual_router.x.template
     virtual_router = panos_panorama_virtual_router.x.name
     enable = false
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf_area" "x" {
     template = panos_ospf.x.template
     virtual_router = panos_ospf.x.virtual_router
     name = "10.1.2.3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ospf_area_virtual_link.md
+++ b/docs/resources/ospf_area_virtual_link.md
@@ -34,27 +34,47 @@ resource "panos_ospf_area_virtual_link" "example" {
     name = "foo"
     neighbor_id = "10.20.40.80"
     transit_area_id = panos_ospf_area.x.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf_area" "x" {
     template = panos_ospf.x.template
     virtual_router = panos_ospf.x.virtual_router
     name = "10.30.40.50"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf" "x" {
     template = panos_panorama_virtual_router.x.template
     virtual_router = panos_panorama_virtual_router.x.name
     enable = false
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "vr name here"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ospf_auth_profile.md
+++ b/docs/resources/ospf_auth_profile.md
@@ -32,20 +32,36 @@ resource "panos_ospf_auth_profile" "example" {
     virtual_router = panos_ospf.x.virtual_router
     name = "my profile"
     password = "secret"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf" "x" {
     template = panos_panorama_template.x.name
     virtual_router = panos_panorama_virtual_router.x.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }       
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ospf_export.md
+++ b/docs/resources/ospf_export.md
@@ -33,20 +33,36 @@ resource "panos_ospf_export" "example" {
     name = "10.2.3.0/24"
     tag = "10.5.15.151"
     metric = 42
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ospf" "x" {
     template = panos_panorama_template.x.name
     virtual_router = panos_panorama_virtual_router.x.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "x" {
     template = panos_panorama_template.x.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }       
 
 resource "panos_panorama_template" "x" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_address_group.md
+++ b/docs/resources/panorama_address_group.md
@@ -35,16 +35,28 @@ resource "panos_panorama_address_group" "example" {
         panos_panorama_address_object.o1.name,
         panos_panorama_address_object.o2.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_address_object" "o1" {
     name = "ntp1"
     value = "192.168.1.1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_address_object" "o2" {
     name = "ntp2"
     value = "192.168.1.1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -54,6 +66,10 @@ resource "panos_panorama_address_group" "example" {
     name = "dynamic grp"
     description = "My internal NTP servers"
     dynamic_match = "'internal' and 'ntp'"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_administrative_tag.md
+++ b/docs/resources/panorama_administrative_tag.md
@@ -72,6 +72,10 @@ resource "panos_panorama_administrative_tag" "example" {
     name = "tag1"
     color = "color5"
     comment = "Internal resources"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_aggregate_interface.md
+++ b/docs/resources/panorama_aggregate_interface.md
@@ -30,10 +30,18 @@ resource "panos_panorama_aggregate_interface" "example" {
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t1" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_application_group.md
+++ b/docs/resources/panorama_application_group.md
@@ -29,16 +29,28 @@ resource "panos_panorama_application_group" "example" {
         panos_panorama_application_group.g1.name,
         panos_panorama_application_group.g2.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_application_object" "g1" {
     name = "app1"
     ...
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_application_object" "g2" {
     name = "app2"
     ...
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_application_signature.md
+++ b/docs/resources/panorama_application_signature.md
@@ -63,6 +63,10 @@ resource "panos_panorama_application_signature" "example" {
             }
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_application_object" "myapp" {
@@ -81,6 +85,10 @@ resource "panos_panorama_application_object" "myapp" {
     risk = 4
     scanning {
         viruses = true
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/panorama_bfd_profile.md
+++ b/docs/resources/panorama_bfd_profile.md
@@ -31,10 +31,18 @@ Panorama
 resource "panos_panorama_bfd_profile" "example" {
     template = panos_panorama_template.t.name
     name = "myBfdProfile"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp.md
+++ b/docs/resources/panorama_bgp.md
@@ -36,15 +36,27 @@ resource "panos_panorama_bgp" "example" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_aggregate.md
+++ b/docs/resources/panorama_bgp_aggregate.md
@@ -30,10 +30,18 @@ resource "panos_panorama_bgp_aggregate" "example" {
     name = "myAggRule"
     prefix = "192.168.1.0/24"
     weight = 17
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_templaet" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -41,11 +49,19 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.vr.name
     router_id = "1.2.3.4"
     as_number = 443
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "vr" {
     template = panos_panorama_template.t.name
     name = "my vr"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_aggregate_advertise_filter.md
+++ b/docs/resources/panorama_bgp_aggregate_advertise_filter.md
@@ -38,10 +38,18 @@ resource "panos_panorama_bgp_aggregate_advertise_filter" "example" {
     address_prefix {
         prefix = "10.1.2.0/24"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_aggregate" "ag" {
@@ -49,6 +57,10 @@ resource "panos_panorama_bgp_aggregate" "ag" {
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "addyAgg1"
     prefix = "192.168.1.0/24"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -56,11 +68,19 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_aggregate_suppress_filter.md
+++ b/docs/resources/panorama_bgp_aggregate_suppress_filter.md
@@ -38,10 +38,18 @@ resource "panos_panorama_bgp_aggregate_suppress_filter" "example" {
     address_prefix {
         prefix = "10.1.2.0/24"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_aggregate" "ag" {
@@ -49,6 +57,10 @@ resource "panos_panorama_bgp_aggregate" "ag" {
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "addyAgg1"
     prefix = "192.168.1.0/24"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -56,11 +68,19 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_auth_profile.md
+++ b/docs/resources/panorama_bgp_auth_profile.md
@@ -21,6 +21,10 @@ resource "panos_panorama_bgp_auth_profile" "example" {
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "prof1"
     secret = "secret"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -28,15 +32,27 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_conditional_adv.md
+++ b/docs/resources/panorama_bgp_conditional_adv.md
@@ -38,10 +38,18 @@ resource "panos_panorama_bgp_conditional_adv" "example" {
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "example"
     enable = false
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_conditional_adv_non_exist_filter" "nef" {
@@ -51,6 +59,10 @@ resource "panos_panorama_bgp_conditional_adv_non_exist_filter" "nef" {
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     name = "nef"
     address_prefixes = ["192.168.1.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_conditional_adv_advertise_filter" "af" {
@@ -60,6 +72,10 @@ resource "panos_panorama_bgp_conditional_adv_advertise_filter" "af" {
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     name = "af"
     address_prefixes = ["192.168.2.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -67,11 +83,19 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_conditional_adv_advertise_filter.md
+++ b/docs/resources/panorama_bgp_conditional_adv_advertise_filter.md
@@ -37,16 +37,28 @@ resource "panos_panorama_bgp_conditional_adv_advertise_filter" "example" {
     name = "af"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.1.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_conditional_adv" "ca" {
     template = panos_panorama_template.t.name
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "example"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_conditional_adv_non_exist_filter" "af" {
@@ -56,6 +68,10 @@ resource "panos_panorama_bgp_conditional_adv_non_exist_filter" "af" {
     name = "nef"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.2.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -63,11 +79,19 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_conditional_adv_non_exist_filter.md
+++ b/docs/resources/panorama_bgp_conditional_adv_non_exist_filter.md
@@ -37,16 +37,28 @@ resource "panos_panorama_bgp_conditional_adv_non_exist_filter" "example" {
     name = "nef"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.1.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_conditional_adv" "ca" {
     template = panos_panorama_template.t.name
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "example"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_conditional_adv_advertise_filter" "af" {
@@ -56,6 +68,10 @@ resource "panos_panorama_bgp_conditional_adv_advertise_filter" "af" {
     name = "af"
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     address_prefixes = ["192.168.2.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -63,11 +79,19 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_dampening_profile.md
+++ b/docs/resources/panorama_bgp_dampening_profile.md
@@ -27,6 +27,10 @@ resource "panos_panorama_bgp_dampening_profile" "example" {
     template = panos_panorama_template.t.name
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "myDampeningProfile"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -34,15 +38,27 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_export_rule_group.md
+++ b/docs/resources/panorama_bgp_export_rule_group.md
@@ -65,6 +65,10 @@ resource "panos_panorama_bgp_export_rule_group" "example" {
         action = "deny"
         match_route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}
@@ -74,15 +78,27 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.vr.name
     router_id = "1.2.3.4"
     as_number = 443
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "vr" {
     template = panos_panorama_template.t.name
     name = "my vr"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_import_rule_group.md
+++ b/docs/resources/panorama_bgp_import_rule_group.md
@@ -65,6 +65,10 @@ resource "panos_panorama_bgp_import_rule_group" "example" {
         action = "deny"
         match_route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}
@@ -74,15 +78,27 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.vr.name
     router_id = "1.2.3.4"
     as_number = 443
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "vr" {
     template = panos_panorama_template.t.name
     name = "my vr"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_peer.md
+++ b/docs/resources/panorama_bgp_peer.md
@@ -48,6 +48,10 @@ resource "panos_panorama_bgp_peer" "example" {
             data.panos_system_info.x.version_minor >= 1 ? 30 : 0
         : 0
     }"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp_peer_group" "pg" {
@@ -55,6 +59,10 @@ resource "panos_panorama_bgp_peer_group" "pg" {
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "myName"
     type = "ibgp"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -62,12 +70,20 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
     interfaces = [panos_panorama_ethernet_interface.e.name]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "e" {
@@ -75,10 +91,18 @@ resource "panos_panorama_ethernet_interface" "e" {
     name = "ethernet1/5"
     mode = "layer3"
     static_ips = ["192.168.1.1/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_peer_group.md
+++ b/docs/resources/panorama_bgp_peer_group.md
@@ -27,6 +27,10 @@ resource "panos_panorama_bgp_peer_group" "example" {
     template = panos_panorama_template.t.name
     virtual_router = panos_panorama_bgp.conf.virtual_router
     name = "myName"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_bgp" "conf" {
@@ -34,15 +38,27 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_bgp_redist_rule.md
+++ b/docs/resources/panorama_bgp_redist_rule.md
@@ -29,6 +29,10 @@ resource "panos_panorama_bgp_redist_rule" "example" {
     route_table = "${data.panos_system_info.x.version_major >= 8 ? "unicast" : ""}"
     name = "192.168.1.0/24"
     set_med = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}
@@ -38,15 +42,27 @@ resource "panos_panorama_bgp" "conf" {
     virtual_router = panos_panorama_virtual_router.rtr.name
     router_id = "5.5.5.5"
     as_number = "42"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "rtr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_email_server_profile.md
+++ b/docs/resources/panorama_email_server_profile.md
@@ -34,6 +34,10 @@ resource "panos_panorama_email_server_profile" "example" {
         to_email = "alerts@example.com"
         email_gateway = "mail.example.com"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_ethernet_interface.md
+++ b/docs/resources/panorama_ethernet_interface.md
@@ -32,10 +32,18 @@ resource "panos_panorama_ethernet_interface" "example1" {
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t1" {
     name = "foo"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -48,10 +56,18 @@ resource "panos_panorama_ethernet_interface" "example2" {
     enable_dhcp = true
     create_dhcp_default_route = true
     dhcp_default_route_metric = 10
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t2" {
     name = "bar"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_gcp_account.md
+++ b/docs/resources/panorama_gcp_account.md
@@ -33,6 +33,10 @@ resource "panos_panorama_gcp_account" "gcp" {
     project_id = "gcp-project-123"
     service_account_credential_type = "gcp"
     credential_file = file("gcp-credentials.json")
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 # A GKE account type (for clusters in a group).
@@ -41,6 +45,10 @@ resource "panos_panorama_gcp_account" "gke" {
     project_id = "gcp-project-123"
     service_account_credential_type = "gke"
     credential_file = file("gcp-credentials.json")
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_gke_cluster.md
+++ b/docs/resources/panorama_gke_cluster.md
@@ -32,6 +32,10 @@ resource "panos_panorama_gke_cluster" "cluster" {
     name = "cluster1"
     gcp_zone = "us-central-1b"
     cluster_credential = panos_panorama_gcp_account.gke.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_gke_cluster_group" "grp" {
@@ -39,14 +43,26 @@ resource "panos_panorama_gke_cluster_group" "grp" {
     gcp_project_credential = panos_panorama_gcp_account.gcp.name
     device_group = panos_device_group.dg.name
     template_stack = panos_panorama_template_stack.ts.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_device_group" "dg" {
     name = "my device group"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template_stack" "ts" {
     name = "myTemplateStack"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_gcp_account" "gcp" {
@@ -54,6 +70,10 @@ resource "panos_panorama_gcp_account" "gcp" {
     project_id = "gcp-project-123"
     service_account_credential_type = "gcp"
     credential_file = file("gcp-credentials.json")
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_gcp_account" "gke" {
@@ -61,6 +81,10 @@ resource "panos_panorama_gcp_account" "gke" {
     project_id = "gcp-project-123"
     service_account_credential_type = "gke"
     credential_file = file("gcp-credentials.json")
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_gke_cluster_group.md
+++ b/docs/resources/panorama_gke_cluster_group.md
@@ -32,14 +32,26 @@ resource "panos_panorama_gke_cluster_group" "grp" {
     gcp_project_credential = panos_panorama_gcp_account.gcp.name
     device_group = panos_panorama_device_group.dg.name
     template_stack = panos_panorama_template_stack.ts.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_device_group" "dg" {
     name = "my device group"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template_stack" "ts" {
     name = "myTemplateStack"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_gcp_account" "gcp" {
@@ -47,6 +59,10 @@ resource "panos_panorama_gcp_account" "gcp" {
     project_id = "gcp-project-123"
     service_account_credential_type = "gcp"
     credential_file = file("gcp-credentials.json")
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_gre_tunnel.md
+++ b/docs/resources/panorama_gre_tunnel.md
@@ -35,10 +35,18 @@ resource "panos_panorama_gre_tunnel" "example" {
     peer_address = "192.168.1.1"
     tunnel_interface = panos_panorama_tunnel_interface.ti.name
     ttl = 42
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "tmpl" {
     name = "My Template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "ei" {
@@ -47,12 +55,20 @@ resource "panos_panorama_ethernet_interface" "ei" {
     vsys = "vsys1"
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_tunnel_interface" "ti" {
     template = panos_panorama_template.tmpl.name
     name = "tunnel.7"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_http_server_profile.md
+++ b/docs/resources/panorama_http_server_profile.md
@@ -35,6 +35,10 @@ resource "panos_panorama_http_server_profile" "example" {
         name = "myServer"
         address = "siem.example.com"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_ike_gateway.md
+++ b/docs/resources/panorama_ike_gateway.md
@@ -30,10 +30,18 @@ resource "panos_panorama_ike_gateway" "example" {
     peer_id_type = "ipaddr"
     peer_id_value = "10.5.1.1"
     ikev1_crypto_profile = "myIkeProfile"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_ipsec_crypto_profile.md
+++ b/docs/resources/panorama_ipsec_crypto_profile.md
@@ -34,10 +34,18 @@ resource "panos_panorama_ipsec_crypto_profile" "example" {
     lifetime_value = 4
     lifesize_type = "mb"
     lifesize_value = 1
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_ipsec_tunnel.md
+++ b/docs/resources/panorama_ipsec_tunnel.md
@@ -30,6 +30,10 @@ resource "panos_panorama_ipsec_tunnel" "example" {
     anti_replay = true
     ak_ike_gateway = panos_panorama_ike_gateway.gw.name
     ak_ipsec_crypto_profile = panos_panorama_ipsec_crypto_profile.p.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_ipsec_tunnel_proxy_id_ipv4.md
+++ b/docs/resources/panorama_ipsec_tunnel_proxy_id_ipv4.md
@@ -33,10 +33,18 @@ resource "panos_panorama_ipsec_tunnel_proxy_id_ipv4" "example" {
     local = "10.1.1.1"
     remote = "10.2.1.1"
     protocol_any = true
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_layer2_subinterface.md
+++ b/docs/resources/panorama_layer2_subinterface.md
@@ -30,6 +30,10 @@ resource "panos_panorama_layer2_subinterface" "example" {
     vsys = "vsys1"
     name = "ethernet1/5.5"
     tag = 5
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "e" {
@@ -37,10 +41,18 @@ resource "panos_panorama_ethernet_interface" "e" {
     name = "ethernet1/5"
     vsys = "vsys1"
     mode = "layer2"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "tmpl" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_layer3_subinterface.md
+++ b/docs/resources/panorama_layer3_subinterface.md
@@ -31,6 +31,10 @@ resource "panos_panorama_layer3_subinterface" "example" {
     tag = 5
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "e" {
@@ -38,10 +42,18 @@ resource "panos_panorama_ethernet_interface" "e" {
     name = "ethernet1/5"
     vsys = "vsys1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "tmpl" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_log_forwarding_profile.md
+++ b/docs/resources/panorama_log_forwarding_profile.md
@@ -54,11 +54,19 @@ resource "panos_panorama_log_forwarding_profile" "example" {
             azure_integration { }
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_administrative_tag" "t" {
     name = "myTag"
     color = "color12"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_loopback_interface.md
+++ b/docs/resources/panorama_loopback_interface.md
@@ -29,10 +29,18 @@ resource "panos_panorama_loopback_interface" "example" {
     template = panos_panorama_template.t.name
     comment = "my loopback interface"
     static_ips = ["10.1.1.1"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_management_profile.md
+++ b/docs/resources/panorama_management_profile.md
@@ -29,10 +29,18 @@ resource "panos_panorama_management_profile" "example" {
     name = "allow ping"
     ping = true
     permitted_ips = ["10.1.1.0/24", "192.168.80.0/24"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_monitor_profile.md
+++ b/docs/resources/panorama_monitor_profile.md
@@ -32,10 +32,18 @@ resource "panos_panorama_monitor_profile" "example" {
     name = "myProfile"
     interval = 5
     threshold = 3
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template_stack" "t" {
     name = "my stack"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_nat_rule.md
+++ b/docs/resources/panorama_nat_rule.md
@@ -50,6 +50,10 @@ resource "panos_panorama_nat_rule" "example" {
         serial = "123456"
         vsys_list = ["vsys1", "vsys2"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_redistribution_profile_ipv4.md
+++ b/docs/resources/panorama_redistribution_profile_ipv4.md
@@ -32,16 +32,28 @@ resource "panos_panorama_redistribution_profile_ipv4" "example" {
     action = "redist"
     types = ["static"]
     interfaces = [panos_panorama_virtual_router.vr.interfaces]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "vr" {
     template = panos_panorama_template.t.name
     name = "my virtual router"
     interfaces = ["ethernet1/2"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_service_group.md
+++ b/docs/resources/panorama_service_group.md
@@ -29,16 +29,28 @@ resource "panos_panorama_service_group" "example" {
         panos_panorama_service_object.o1.name,
         panos_panorama_service_object.o2.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_service_object" "o1" {
     name = "svc1"
     ...
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_service_object" "o2" {
     name = "svc2"
     ...
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_service_object.md
+++ b/docs/resources/panorama_service_object.md
@@ -30,6 +30,10 @@ resource "panos_panorama_service_object" "example" {
     source_port = "2000-2049,2051-2099"
     destination_port = "32123"
     tags = ["internal", "dmz"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_snmptrap_server_profile.md
+++ b/docs/resources/panorama_snmptrap_server_profile.md
@@ -24,6 +24,10 @@ resource "panos_panorama_snmptrap_server_profile" "example" {
         manager = "snmp1.example.com"
         community = "public"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_static_route_ipv4.md
+++ b/docs/resources/panorama_static_route_ipv4.md
@@ -30,15 +30,27 @@ resource "panos_panorama_static_route_ipv4" "example" {
     name = "localnet"
     destination = "10.1.7.0/32"
     next_hop = "10.1.7.4"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_virtual_router" "vr1" {
     name = "my virtual router"
     template = panos_panorama_template.t.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "template1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_syslog_server_profile.md
+++ b/docs/resources/panorama_syslog_server_profile.md
@@ -31,6 +31,10 @@ resource "panos_panorama_syslog_server_profile" "example" {
         name = "my-server"
         server = "syslog.example.com"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_template.md
+++ b/docs/resources/panorama_template.md
@@ -48,6 +48,10 @@ resource "panos_panorama_template" "example" {
         serial = "44556677"
         vsys_list = ["vsys1", "vsys2"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_template_entry.md
+++ b/docs/resources/panorama_template_entry.md
@@ -42,6 +42,10 @@ Panorama
 resource "panos_panorama_template_entry" "example1" {
     template = panos_panorama_template.t.name
     serial = "00112233"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 # Example for a physical firewall with multi-vsys enabled.
@@ -49,10 +53,18 @@ resource "panos_panorama_template_entry" "example2" {
     template = panos_panorama_template.t.name
     serial = "44556677"
     vsys_list = ["vsys1", "vsys2"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_template_stack.md
+++ b/docs/resources/panorama_template_stack.md
@@ -37,6 +37,10 @@ resource "panos_panorama_template_stack" "example" {
     description = "description here"
     templates = ["t1", "t2"]
     devices = ["00112233", "44556677"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_template_stack_entry.md
+++ b/docs/resources/panorama_template_stack_entry.md
@@ -36,10 +36,18 @@ Panorama
 resource "panos_panorama_template_stack_entry" "example1" {
     template_stack = panos_panorama_template_stack.t.name
     device = "00112233"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template_stack" "t" {
     name = "my template stack"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_template_variable.md
+++ b/docs/resources/panorama_template_variable.md
@@ -34,10 +34,18 @@ resource "panos_panorama_template_variable" "example" {
     name = "$example"
     type = "ip-address"
     value = "10.1.1.1/24"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "tmpl1" {
     name = "MyTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_tunnel_interface.md
+++ b/docs/resources/panorama_tunnel_interface.md
@@ -29,10 +29,18 @@ resource "panos_panorama_tunnel_interface" "example1" {
     name = "tunnel.5"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "foo"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_vlan.md
+++ b/docs/resources/panorama_vlan.md
@@ -27,16 +27,28 @@ resource "panos_panorama_vlan" "example" {
     template = panos_panorama_template.t.name
     name = "myVlan"
     vlan_interface = panos_panorama_vlan_interface.vli.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_vlan_interface" "vli" {
     template = panos_panorama_template.t.name
     name = "vlan.6"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "myTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_vlan_entry.md
+++ b/docs/resources/panorama_vlan_entry.md
@@ -31,15 +31,27 @@ resource "panos_panorama_vlan_entry" "example" {
         "00:30:48:55:66:77",
         "00:30:48:55:66:88",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_vlan" "vlan1" {
     template = panos_panorama_template.t.name
     name = "myVlan"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "e1" {
@@ -47,6 +59,10 @@ resource "panos_panorama_ethernet_interface" "e1" {
     name = "ethernet1/5"
     mode = "layer2"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/panorama_vlan_interface.md
+++ b/docs/resources/panorama_vlan_interface.md
@@ -30,10 +30,18 @@ resource "panos_panorama_vlan_interface" "example" {
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "t" {
     name = "my template"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/pbf_rule_group.md
+++ b/docs/resources/pbf_rule_group.md
@@ -60,11 +60,19 @@ resource "panos_pbf_rule_group" "example" {
             action = "discard"
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "foo" {
     name = "myZone"
     mode = "layer2"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/redistribution_profile_ipv4.md
+++ b/docs/resources/redistribution_profile_ipv4.md
@@ -31,11 +31,19 @@ resource "panos_redistribution_profile_ipv4" "example" {
     action = "redist"
     types = ["static"]
     interfaces = [panos_virtual_router.vr.interfaces.0]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "vr" {
     name = "my virtual router"
     interfaces = ["ethernet1/2"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -74,6 +74,10 @@ resource "panos_security_policy" "example" {
         categories = ["any"]
         action = "allow"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/security_profile_group.md
+++ b/docs/resources/security_profile_group.md
@@ -27,6 +27,10 @@ resource "panos_security_profile_group" "example" {
     name = "myGroup"
     antivirus_profile = "default"
     anti_spyware_profile = "anti-spyware1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/security_rule_group.md
+++ b/docs/resources/security_rule_group.md
@@ -109,6 +109,10 @@ resource "panos_security_rule_group" "example1" {
         categories = ["any"]
         action = "deny"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_security_rule_group" "example2" {
@@ -126,26 +130,46 @@ resource "panos_security_rule_group" "example2" {
         categories = ["any"]
         action = "deny"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "bizdev" {
     name = "bizdev"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "dmz" {
     name = "dmz"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "sales" {
     name = "sales"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "eng" {
     name = "eng"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -194,6 +218,10 @@ resource "panos_security_rule_group" "example1" {
             ]
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_security_rule_group" "example2" {
@@ -211,6 +239,10 @@ resource "panos_security_rule_group" "example2" {
         services = ["application-default"]
         categories = ["any"]
         action = "deny"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/service_group.md
+++ b/docs/resources/service_group.md
@@ -28,6 +28,10 @@ resource "panos_service_group" "example" {
     services = [
         panos_service_object.o1.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_service_object" "o1" {
@@ -35,6 +39,10 @@ resource "panos_service_object" "o1" {
     protocol = "tcp"
     source_port = "2000-2049"
     destination_port = "32123"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/service_object.md
+++ b/docs/resources/service_object.md
@@ -31,6 +31,10 @@ resource "panos_service_object" "example" {
     source_port = "2000-2049,2051-2099"
     destination_port = "32123"
     tags = ["internal", "dmz"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/snmptrap_server_profile.md
+++ b/docs/resources/snmptrap_server_profile.md
@@ -23,6 +23,10 @@ resource "panos_snmptrap_server_profile" "example" {
         manager = "snmp1.example.com"
         community = "public"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/ssl_decrypt.md
+++ b/docs/resources/ssl_decrypt.md
@@ -36,6 +36,10 @@ NGFW and Panorama.
 resource "panos_ssl_decrypt" "example" {
     forward_trust_certificate_rsa = panos_certificate_import.trust.name
     forward_untrust_certificate_rsa = panos_certificate_import.untrust.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_certificate_import" "trust" {
@@ -45,6 +49,10 @@ resource "panos_certificate_import" "trust" {
         private_key = file("key.pem")
         passphrase = "secret"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_certificate_import" "untrust" {
@@ -53,6 +61,10 @@ resource "panos_certificate_import" "untrust" {
         certificate = file("untrust-cert.pem")
         private_key = file("untrust-key.pem")
         passphrase = "foobar"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/ssl_decrypt_trusted_root_ca_entry.md
+++ b/docs/resources/ssl_decrypt_trusted_root_ca_entry.md
@@ -38,6 +38,10 @@ resource "panos_ssl_decrypt_trusted_root_ca_entry" "example" {
     template = panos_ssl_decrypt.x.template
     template_stack = panos_ssl_decrypt.x.template_stack
     certificate_name = panos_certificate_import.trust.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ssl_decrypt" "x" {}
@@ -48,6 +52,10 @@ resource "panos_certificate_import" "trust" {
         certificate = file("cert.pem")
         private_key = file("key.pem")
         passphrase = "secret"
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/static_route_ipv4.md
+++ b/docs/resources/static_route_ipv4.md
@@ -29,10 +29,18 @@ resource "panos_static_route_ipv4" "example" {
     virtual_router = panos_virtual_router.vr1.name
     destination = "10.1.7.0/32"
     next_hop = "10.1.7.4"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "vr1" {
     name = "my virtual router"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/syslog_server_profile.md
+++ b/docs/resources/syslog_server_profile.md
@@ -30,6 +30,10 @@ resource "panos_syslog_server_profile" "example" {
         name = "my-server"
         server = "syslog.example.com"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -35,6 +35,10 @@ resource "panos_telemetry" "example" {
     threat_prevention_reports = true
     threat_prevention_data = true
     threat_prevention_packet_captures = true
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/tunnel_interface.md
+++ b/docs/resources/tunnel_interface.md
@@ -27,6 +27,10 @@ resource "panos_tunnel_interface" "example1" {
     name = "tunnel.5"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/url_filtering_security_profile.md
+++ b/docs/resources/url_filtering_security_profile.md
@@ -54,6 +54,10 @@ resource "panos_url_filtering_security_profile" "example" {
             value = "beta"
         }
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 data "panos_system_info" "x" {}

--- a/docs/resources/user_tag.md
+++ b/docs/resources/user_tag.md
@@ -25,6 +25,10 @@ resource "panos_user_tag" "example1" {
         "tag1",
         "tag2",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 # It is safe to have multiple resources target the same user.
@@ -33,6 +37,10 @@ resource "panos_user_tag" "example2" {
     tags = [
         "tag3",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/userid_login.md
+++ b/docs/resources/userid_login.md
@@ -19,6 +19,10 @@ NGFW
 resource "panos_userid_login" "example" {
     ip = "10.2.3.4"
     user = "user1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/virtual_router.md
+++ b/docs/resources/virtual_router.md
@@ -46,18 +46,30 @@ resource "panos_virtual_router" "example" {
         panos_ethernet_interface.e1.name,
         panos_ethernet_interface.e2.name,
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e1" {
     vsys = "vsys1"
     name = "ethernet1/1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e2" {
     vsys = "vsys1"
     name = "ethernet1/2"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/virtual_router_entry.md
+++ b/docs/resources/virtual_router_entry.md
@@ -37,15 +37,27 @@ NGFW and Panorama.
 resource "panos_virtual_router_entry" "example" {
     virtual_router = panos_virtual_router.vr.name
     interface = panos_ethernet_interface.e.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_virtual_router" "vr" {
     name = "my vr"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e" {
     name = "ethernet1/1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -26,11 +26,19 @@ NGFW
 resource "panos_vlan" "example" {
     name = "myVlan"
     vlan_interface = panos_vlan_interface.vli.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_vlan_interface" "vli" {
     name = "vlan.6"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/vlan_entry.md
+++ b/docs/resources/vlan_entry.md
@@ -30,16 +30,28 @@ resource "panos_vlan_entry" "example" {
         "00:30:48:55:66:77",
         "00:30:48:55:66:88",
     ]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_vlan" "vlan1" {
     name = "myVlan"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e1" {
     name = "ethernet1/5"
     mode = "layer2"
     vsys = "vsys1"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/vlan_interface.md
+++ b/docs/resources/vlan_interface.md
@@ -29,6 +29,10 @@ resource "panos_vlan_interface" "example" {
     mode = "layer3"
     static_ips = ["10.1.1.1/24"]
     comment = "Configured for internal traffic"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/vm_auth_key.md
+++ b/docs/resources/vm_auth_key.md
@@ -17,6 +17,10 @@ Creates a VM auth key you can use to bootstrap a VM NGFW.
 # Basic usage.
 resource "panos_vm_auth_key" "example1" {
     hours = 24
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -27,6 +31,10 @@ resource "panos_vm_auth_key" "example2" {
 
     keepers = {
         rotate = time_rotating.tr.rotation_rfc3339
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 

--- a/docs/resources/vm_information_source.md
+++ b/docs/resources/vm_information_source.md
@@ -33,6 +33,10 @@ resource "panos_vm_information_source" "ex1" {
         secret_access_key = "abcd1234abcd12345"
         vpc_id = "myVpcId"
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -49,6 +53,10 @@ resource "panos_vm_information_source" "ex2" {
         username = "user"
         password = "pass"
         update_interval = 6
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```
@@ -67,6 +75,10 @@ resource "panos_vm_information_source" "ex3" {
         password = "pass"
         update_interval = 6
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -83,6 +95,10 @@ resource "panos_vm_information_source" "ex4" {
         update_interval = 120
         enable_timeout = true
         timeout = 3
+    }
+
+    lifecycle {
+        create_before_destroy = true
     }
 }
 ```

--- a/docs/resources/vulnerability_security_profile.md
+++ b/docs/resources/vulnerability_security_profile.md
@@ -48,6 +48,10 @@ resource "panos_vulnerability_security_profile" "example" {
 data "panos_predefined_threat" "siemens_overflow" {
     threat_type = "vulnerability"
     threat_name = "Siemens Tecnomatix FactoryLink SCADA CSService Buffer Overflow Vulnerability"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/wildfire_analysis_security_profile.md
+++ b/docs/resources/wildfire_analysis_security_profile.md
@@ -37,6 +37,10 @@ resource "panos_wildfire_analysis_security_profile" "example" {
         applications = ["pop3"]
         file_types = ["pdf"]
     }
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -44,16 +44,28 @@ resource "panos_zone" "example" {
     ]
     enable_user_id = true
     exclude_acls = ["192.168.0.0/16"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e1" {
     name = "ethernet1/1"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e5" {
     name = "ethernet1/5"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 
@@ -70,22 +82,38 @@ resource "panos_zone" "example" {
     ]
     enable_user_id = true
     exclude_acls = ["192.168.0.0/16"]
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_template" "tmpl1" {
     name = "MyTemplate"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "e2" {
     template = panos_panorama_template.tmpl1.name
     name = "ethernet1/2"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_panorama_ethernet_interface" "e3" {
     template = panos_panorama_template.tmpl1.name
     name = "ethernet1/3"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 

--- a/docs/resources/zone_entry.md
+++ b/docs/resources/zone_entry.md
@@ -40,16 +40,28 @@ resource "panos_zone_entry" "example" {
     zone = panos_zone.z.name
     mode = panos_zone.z.mode
     interface = panos_ethernet_interface.e5.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_ethernet_interface" "e5" {
     name = "ethernet1/5"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "panos_zone" "z" {
     name = "exZone"
     mode = "layer3"
+
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 ```
 


### PR DESCRIPTION
## Description

Appending Terraform's `lifecycle` meta-argument to each example of resources.

## Motivation and Context

This is an enhancement to existing documentation, where resources will now have the following added within the Markdown files:

```hcl
    lifecycle {
        create_before_destroy = true
    }
```

#355 

## How Has This Been Tested?

No code is being altered, this is explicitly targeting public documentation. Markdown linters appear to be pleased with the modifications.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
