### PR TITLE
Added capability to put login banner using general_settings

### DIFF
--- a/panos/resource_general_settings.go
+++ b/panos/resource_general_settings.go
@@ -146,6 +146,12 @@ func resourceGeneralSettings() *schema.Resource {
 				Computed:    true,
 				Description: "NTP symmetric-key auth key",
 			},
+			"login_banner": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Banner shown in login page",
+			},
 		},
 	}
 }
@@ -173,6 +179,7 @@ func parseGeneralSettings(d *schema.ResourceData) general.Config {
 		NtpSecondaryKeyId:     d.Get("ntp_secondary_key_id").(int),
 		NtpSecondaryAlgorithm: d.Get("ntp_secondary_algorithm").(string),
 		NtpSecondaryAuthKey:   d.Get("ntp_secondary_auth_key").(string),
+		LoginBanner:           d.Get("login_banner").(string),
 	}
 }
 
@@ -239,6 +246,7 @@ func readGeneralSettings(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ntp_secondary_key_id", o.NtpSecondaryKeyId)
 	d.Set("ntp_secondary_algorithm", o.NtpSecondaryAlgorithm)
 	d.Set("ntp_secondary_auth_key", o.NtpSecondaryAuthKey)
+	d.Set("login_banner", o.LoginBanner)
 
 	return nil
 }

--- a/panos/resource_general_settings_test.go
+++ b/panos/resource_general_settings_test.go
@@ -23,17 +23,17 @@ func TestAccPanosGeneralSettings_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGeneralSettingsConfig("acctest", "10.5.5.5", "10.10.10.10", "autokey"),
+				Config: testAccGeneralSettingsConfig("acctest", "10.5.5.5", "10.10.10.10", "autokey", "testing_banner"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPanosGeneralSettingsExists("panos_general_settings.test", &o),
-					testAccCheckPanosGeneralSettingsAttributes(&o, "acctest", "10.5.5.5", "10.10.10.10", "autokey"),
+					testAccCheckPanosGeneralSettingsAttributes(&o, "acctest", "10.5.5.5", "10.10.10.10", "autokey", "testing_banner"),
 				),
 			},
 			{
-				Config: testAccGeneralSettingsConfig("ngfw", "10.15.15.15", "10.20.20.20", "none"),
+				Config: testAccGeneralSettingsConfig("ngfw", "10.15.15.15", "10.20.20.20", "none", "testing_banner"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPanosGeneralSettingsExists("panos_general_settings.test", &o),
-					testAccCheckPanosGeneralSettingsAttributes(&o, "ngfw", "10.15.15.15", "10.20.20.20", "none"),
+					testAccCheckPanosGeneralSettingsAttributes(&o, "ngfw", "10.15.15.15", "10.20.20.20", "none", "testing_banner"),
 				),
 			},
 		},
@@ -63,7 +63,7 @@ func testAccCheckPanosGeneralSettingsExists(n string, o *general.Config) resourc
 	}
 }
 
-func testAccCheckPanosGeneralSettingsAttributes(o *general.Config, h, ds, nsa, nsat string) resource.TestCheckFunc {
+func testAccCheckPanosGeneralSettingsAttributes(o *general.Config, h, ds, nsa, nsat, loginBanner string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if o.Hostname != h {
 			return fmt.Errorf("Hostname is %s, expected %s", o.Hostname, h)
@@ -81,17 +81,22 @@ func testAccCheckPanosGeneralSettingsAttributes(o *general.Config, h, ds, nsa, n
 			return fmt.Errorf("Hostname is %s, expected %s", o.NtpSecondaryAuthType, nsat)
 		}
 
+		if o.LoginBanner != loginBanner {
+			return fmt.Errorf("Login Banner is %s, expected %s", o.LoginBanner, loginBanner)
+		}
+
 		return nil
 	}
 }
 
-func testAccGeneralSettingsConfig(h, ds, nsa, nsat string) string {
+func testAccGeneralSettingsConfig(h, ds, nsa, nsat, loginBanner string) string {
 	return fmt.Sprintf(`
 resource "panos_general_settings" "test" {
     hostname = "%s"
     dns_secondary = "%s"
     ntp_secondary_address = "%s"
     ntp_secondary_auth_type = "%s"
+		login_banner = "%s"
 }
-`, h, ds, nsa, nsat)
+`, h, ds, nsa, nsat, loginBanner)
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR is to add capability to put login banner using general settings resource block

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
As we try to automate further, I feel that a lot of consumer will benefit from having an ability to add login banner programmatically. While making this change I noticed that Pango already has login banner in its config, so I just needed to enable login banner within provider code base.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
This was tested via Panos environment

- Before the change 
![image](https://user-images.githubusercontent.com/113461575/221965231-1da2d0b9-4e2c-419b-9754-f87fca15d0d7.png)

- Adding the login banner in the resource block
![image](https://user-images.githubusercontent.com/113461575/221965810-2ee526dd-69cd-4a08-93dd-2086b17abf74.png)

- Able to read the changes that are being made
![image](https://user-images.githubusercontent.com/113461575/221966222-e51f5f18-d739-4076-8c15-0bd75335a8ac.png)

- After applying and running the firewall-commit binary
![image](https://user-images.githubusercontent.com/113461575/221966601-1b25df79-d494-48cc-b793-9ac08d512f98.png)


<!--- Include details of your testing environment, and the tests you ran to -->
This was tested on VM-series of Pan OS deployed in Cloud and applying the changes using the Terraform to the instance.
<!--- see how your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
