### PR TITLE
Add packet buffer protection flag for zones.

### DIFF
--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -145,3 +145,4 @@ The following arguments are supported:
 * `exclude_acls` - Users from these addresses/subnets will not
   be identified.  This can be an address object, an address group, a single
   IP address, or an IP address subnet.
+* `enable_packet_buffer_protection` - Boolean to enable packet buffer protection. Defaults to true.

--- a/panos/resource_panorama_zone_test.go
+++ b/panos/resource_panorama_zone_test.go
@@ -27,17 +27,17 @@ func TestAccPanosPanoramaZone_basic(t *testing.T) {
 		CheckDestroy: testAccPanosPanoramaZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPanosPanoramaZoneConfig(ts, name, "10.1.1.0/24", "192.168.1.0/24", true),
+				Config: testAccPanosPanoramaZoneConfig(ts, name, "10.1.1.0/24", "192.168.1.0/24", true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPanosPanoramaZoneExists("panos_panorama_zone.test", &o),
-					testAccCheckPanosPanoramaZoneAttributes(&o, name, "10.1.1.0/24", "192.168.1.0/24", true),
+					testAccCheckPanosPanoramaZoneAttributes(&o, name, "10.1.1.0/24", "192.168.1.0/24", true, true),
 				),
 			},
 			{
-				Config: testAccPanosPanoramaZoneConfig(ts, name, "192.168.3.0/24", "10.1.3.0/24", false),
+				Config: testAccPanosPanoramaZoneConfig(ts, name, "192.168.3.0/24", "10.1.3.0/24", false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPanosPanoramaZoneExists("panos_panorama_zone.test", &o),
-					testAccCheckPanosPanoramaZoneAttributes(&o, name, "192.168.3.0/24", "10.1.3.0/24", false),
+					testAccCheckPanosPanoramaZoneAttributes(&o, name, "192.168.3.0/24", "10.1.3.0/24", false, false),
 				),
 			},
 		},
@@ -68,7 +68,7 @@ func testAccCheckPanosPanoramaZoneExists(n string, o *zone.Entry) resource.TestC
 	}
 }
 
-func testAccCheckPanosPanoramaZoneAttributes(o *zone.Entry, name, inc, exc string, eui bool) resource.TestCheckFunc {
+func testAccCheckPanosPanoramaZoneAttributes(o *zone.Entry, name, inc, exc string, eui bool, pbp bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if o.Name != name {
 			return fmt.Errorf("Name is %s, expected %s", o.Name, name)
@@ -84,6 +84,10 @@ func testAccCheckPanosPanoramaZoneAttributes(o *zone.Entry, name, inc, exc strin
 
 		if o.EnableUserId != eui {
 			return fmt.Errorf("Enable User Id is %t, expected %t", o.EnableUserId, eui)
+		}
+
+		if o.EnablePacketBufferProtection != pbp {
+			return fmt.Errorf("Enable packet buffer protiection is %t, expected %t", o.EnablePacketBufferProtection, pbp)
 		}
 
 		return nil
@@ -111,7 +115,7 @@ func testAccPanosPanoramaZoneDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccPanosPanoramaZoneConfig(ts, name, inc, exc string, eui bool) string {
+func testAccPanosPanoramaZoneConfig(ts, name, inc, exc string, eui bool, pbp bool) string {
 	return fmt.Sprintf(`
 resource "panos_panorama_template_stack" "x" {
     name = %q
@@ -124,6 +128,7 @@ resource "panos_panorama_zone" "test" {
     include_acls = [%q]
     exclude_acls = [%q]
     enable_user_id = %t
+	enable_packet_buffer_protection = %t
 }
-`, ts, name, inc, exc, eui)
+`, ts, name, inc, exc, eui, pbp)
 }

--- a/panos/zones.go
+++ b/panos/zones.go
@@ -505,6 +505,12 @@ func zoneSchema(isResource bool, rmKeys []string) map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"enable_packet_buffer_protection": {
+			Type:        schema.TypeBool,
+			Description: "Boolean to enable packet buffer protection.",
+			Optional:    true,
+			Default:     true,
+		},
 	}
 
 	for _, rmKey := range rmKeys {
@@ -560,14 +566,15 @@ func zoneEntrySchema(withTmpl, withTs bool) map[string]*schema.Schema {
 
 func loadZone(d *schema.ResourceData) zone.Entry {
 	return zone.Entry{
-		Name:         d.Get("name").(string),
-		Mode:         d.Get("mode").(string),
-		ZoneProfile:  d.Get("zone_profile").(string),
-		LogSetting:   d.Get("log_setting").(string),
-		EnableUserId: d.Get("enable_user_id").(bool),
-		Interfaces:   asStringList(d.Get("interfaces").([]interface{})),
-		IncludeAcls:  asStringList(d.Get("include_acls").([]interface{})),
-		ExcludeAcls:  asStringList(d.Get("exclude_acls").([]interface{})),
+		Name:                         d.Get("name").(string),
+		Mode:                         d.Get("mode").(string),
+		ZoneProfile:                  d.Get("zone_profile").(string),
+		LogSetting:                   d.Get("log_setting").(string),
+		EnableUserId:                 d.Get("enable_user_id").(bool),
+		Interfaces:                   asStringList(d.Get("interfaces").([]interface{})),
+		IncludeAcls:                  asStringList(d.Get("include_acls").([]interface{})),
+		ExcludeAcls:                  asStringList(d.Get("exclude_acls").([]interface{})),
+		EnablePacketBufferProtection: d.Get("enable_packet_buffer_protection").(bool),
 	}
 }
 
@@ -586,7 +593,7 @@ func saveZone(d *schema.ResourceData, o zone.Entry) {
 	if err := d.Set("exclude_acls", o.ExcludeAcls); err != nil {
 		log.Printf("[WARN] Error setting 'exclude_acls' param for %q: %s", d.Id(), err)
 	}
-
+	d.Set("enable_packet_buffer_protection", o.EnablePacketBufferProtection)
 }
 
 // Id functions.


### PR DESCRIPTION
## Description

Add packet buffer protection flag for zones.

## Motivation and Context

I've added the ability to manage packet buffer protection for zones, which is currently missing. For consistency with web UI, I've set the flag as enabled by default.

Thanks for reviewing this. 