### PR TITLE
Support tags with colon in name

### DIFF
--- a/panos/resource_administrative_tag.go
+++ b/panos/resource_administrative_tag.go
@@ -58,7 +58,7 @@ func parseAdministrativeTag(d *schema.ResourceData) (string, tags.Entry) {
 }
 
 func parseAdministrativeTagId(v string) (string, string) {
-	t := strings.Split(v, IdSeparator)
+	t := strings.SplitN(v, IdSeparator, 2)
 	return t[0], t[1]
 }
 

--- a/panos/resource_panorama_administrative_tag.go
+++ b/panos/resource_panorama_administrative_tag.go
@@ -58,7 +58,7 @@ func parsePanoramaAdministrativeTag(d *schema.ResourceData) (string, tags.Entry)
 }
 
 func parsePanoramaAdministrativeTagId(v string) (string, string) {
-	t := strings.Split(v, IdSeparator)
+	t := strings.SplitN(v, IdSeparator, 2)
 	return t[0], t[1]
 }
 


### PR DESCRIPTION
## Description

Changed function for reading administrative tags

## Motivation and Context

Administrative tags with colon in name cannot be imported. They can be created but not added to state.

## How Has This Been Tested?

I tested this on our Panorama setup.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
